### PR TITLE
Top level wrapper

### DIFF
--- a/crates/matrix-sdk/src/widget_api/api/mod.rs
+++ b/crates/matrix-sdk/src/widget_api/api/mod.rs
@@ -21,7 +21,7 @@ use super::{
 
 #[macro_use]
 mod process_macro;
-mod widget;
+pub mod widget;
 
 pub type PendingResponses = Arc<Mutex<HashMap<String, oneshot::Sender<ToWidgetAction>>>>;
 

--- a/crates/matrix-sdk/src/widget_api/mod.rs
+++ b/crates/matrix-sdk/src/widget_api/mod.rs
@@ -7,8 +7,19 @@ pub mod handler;
 pub mod matrix;
 pub mod messages;
 
-pub use self::error::{Error, Result};
+pub use self::{
+    api::{run, widget::Widget},
+    error::{Error, Result},
+    matrix::{Driver as MatrixDriver, PermissionProvider},
+};
+use crate::room::Joined as JoinedRoom;
 
-pub fn run_client_widget_api() {
-    println!("Hello, world!");
+/// Runs client widget API for a given `widget` with a given `permission_manager` within a given `room`.
+/// The function returns once the API is completed (the widget disconnected etc).
+pub async fn run_client_widget_api(
+    widget: Widget,
+    permission_manager: impl PermissionProvider,
+    room: JoinedRoom,
+) -> Result<()> {
+    run(MatrixDriver::new(room, permission_manager), widget).await
 }


### PR DESCRIPTION
Now, when all our "Lego pieces" are ready, the wrapper is dead simple 🙂 Alternatively, we could also wrap the trait along with the `Widget` structure into another crate, then there will be 2 parameters to the top-level function: a joined room and a widget.