### PR TITLE
widget_api: properly handle init on load behavior

### DIFF
--- a/crates/matrix-sdk/src/widget_api/api/mod.rs
+++ b/crates/matrix-sdk/src/widget_api/api/mod.rs
@@ -35,10 +35,8 @@ pub async fn run<T: Client>(client: T, mut widget: widget::Widget) -> Result<()>
     tokio::spawn(forward(outgoing_req_rx, widget.comm.sink()));
 
     // Create a message handler (handles all incoming requests and generates outgoing requests).
-    let handler = {
-        let widget = WidgetSink::new(widget.info, outgoing_req_tx, state.clone());
-        MessageHandler::new(client, widget).await?
-    };
+    let handler =
+        MessageHandler::new(client, WidgetSink::new(widget.info, outgoing_req_tx, state.clone()));
 
     // Spawn a task that receives requests from a widget, and passes them
     // to the handler, waits for response from a handler and sends it back.

--- a/crates/matrix-sdk/src/widget_api/handler/mod.rs
+++ b/crates/matrix-sdk/src/widget_api/handler/mod.rs
@@ -30,13 +30,8 @@ pub struct MessageHandler<C, W> {
 }
 
 impl<C: Client, W: Widget> MessageHandler<C, W> {
-    pub async fn new(client: C, widget: W) -> Result<Self> {
-        let mut handler = Self { client, widget, capabilities: None };
-        if !handler.widget.init_on_load() {
-            handler.initialise().await?;
-        }
-
-        Ok(handler)
+    pub fn new(client: C, widget: W) -> Self {
+        Self { client, widget, capabilities: None }
     }
 
     pub async fn handle(&mut self, req: Incoming) -> Result<()> {
@@ -57,6 +52,10 @@ impl<C: Client, W: Widget> MessageHandler<C, W> {
 
             Incoming::GetSupportedApiVersion(r) => {
                 r.reply(Ok(SupportedVersions { versions: SUPPORTED_API_VERSIONS.to_vec() }))?;
+
+                if self.capabilities.is_none() && !self.widget.init_on_load() {
+                    self.initialise().await?;
+                }
             }
 
             Incoming::GetOpenID(r) => {


### PR DESCRIPTION
@toger5, it turned out to be really trivial to implement this logic given that we know that the widget always sends the versions request before performing any actions!