### PR TITLE
Empty type

### DIFF
--- a/crates/matrix-sdk/src/widget_api/handler/incoming.rs
+++ b/crates/matrix-sdk/src/widget_api/handler/incoming.rs
@@ -1,3 +1,5 @@
+use crate::widget_api::messages::Empty;
+
 use super::{
     super::messages::{
         from_widget::{ReadEventRequest, ReadEventResponse, SendEventRequest, SendEventResponse},
@@ -8,8 +10,8 @@ use super::{
 
 #[allow(missing_debug_implementations)]
 pub enum Message {
-    GetSupportedApiVersion(Request<(), SupportedVersions>),
-    ContentLoaded(Request<(), ()>),
+    GetSupportedApiVersion(Request<Empty, SupportedVersions>),
+    ContentLoaded(Request<Empty, Empty>),
     GetOpenID(Request<openid::Request, openid::State>),
     ReadEvents(Request<ReadEventRequest, ReadEventResponse>),
     SendEvent(Request<SendEventRequest, SendEventResponse>),

--- a/crates/matrix-sdk/src/widget_api/handler/mod.rs
+++ b/crates/matrix-sdk/src/widget_api/handler/mod.rs
@@ -44,9 +44,9 @@ impl<C: Client, W: Widget> MessageHandler<C, W> {
             Incoming::ContentLoaded(r) => {
                 let (response, negotiate) =
                     match (self.widget.init_on_load(), self.capabilities.as_ref()) {
-                        (true, None) => (Ok(()), true),
+                        (true, None) => (Ok(Empty{}), true),
                         (true, Some(..)) => (Err(Error::AlreadyLoaded), false),
-                        _ => (Ok(()), false),
+                        _ => (Ok(Empty{}), false),
                     };
 
                 r.reply(response)?;

--- a/crates/matrix-sdk/src/widget_api/handler/mod.rs
+++ b/crates/matrix-sdk/src/widget_api/handler/mod.rs
@@ -17,7 +17,7 @@ use super::{
         capabilities::Options as CapabilitiesReq,
         from_widget::{ReadEventRequest, ReadEventResponse, SendEventRequest, SendEventResponse},
         to_widget::CapabilitiesUpdatedRequest as CapabilitiesUpdated,
-        SupportedVersions, SUPPORTED_API_VERSIONS,
+        SupportedVersions, SUPPORTED_API_VERSIONS, Empty
     },
     Error, Result,
 };

--- a/crates/matrix-sdk/src/widget_api/handler/outgoing.rs
+++ b/crates/matrix-sdk/src/widget_api/handler/outgoing.rs
@@ -2,7 +2,7 @@ use crate::widget_api::messages::{
     capabilities::Options,
     openid::State as OpenIDState,
     to_widget::{CapabilitiesUpdatedRequest, ToWidgetMessage},
-    Header, MessageBody,
+    Header, MessageBody, Empty,
 };
 
 use super::{Error, Result};
@@ -19,7 +19,7 @@ impl OutgoingMessage for SendMeCapabilities {
     type Response = Options;
 
     fn into_message(self, header: Header) -> ToWidgetMessage {
-        ToWidgetMessage::SendMeCapabilities(MessageBody::request(header, ()))
+        ToWidgetMessage::SendMeCapabilities(MessageBody::request(header, Empty{}))
     }
 
     fn extract_response(msg: ToWidgetMessage) -> Result<Self::Response> {
@@ -32,7 +32,7 @@ impl OutgoingMessage for SendMeCapabilities {
 
 pub struct CapabilitiesUpdated(pub CapabilitiesUpdatedRequest);
 impl OutgoingMessage for CapabilitiesUpdated {
-    type Response = ();
+    type Response = Empty;
 
     fn into_message(self, header: Header) -> ToWidgetMessage {
         ToWidgetMessage::CapabilitiesUpdated(MessageBody::request(header, self.0))
@@ -48,7 +48,7 @@ impl OutgoingMessage for CapabilitiesUpdated {
 
 pub struct OpenIDUpdated(pub OpenIDState);
 impl OutgoingMessage for OpenIDUpdated {
-    type Response = ();
+    type Response = Empty;
 
     fn into_message(self, header: Header) -> ToWidgetMessage {
         ToWidgetMessage::OpenIdCredentials(MessageBody::request(header, self.0))

--- a/crates/matrix-sdk/src/widget_api/messages/from_widget.rs
+++ b/crates/matrix-sdk/src/widget_api/messages/from_widget.rs
@@ -1,16 +1,16 @@
 use serde::{Deserialize, Serialize};
 
-use super::{openid, MatrixEvent, MessageBody, ReadRelationsDirection, SupportedVersions};
+use super::{openid, MatrixEvent, MessageBody, ReadRelationsDirection, SupportedVersions, Empty};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "action")]
 pub enum FromWidgetMessage {
     #[serde(rename = "supported_api_versions")]
-    GetSupportedApiVersion(MessageBody<(), SupportedVersions>),
+    GetSupportedApiVersion(MessageBody<Empty, SupportedVersions>),
     #[serde(rename = "content_loaded")]
-    ContentLoaded(MessageBody<(), ()>),
+    ContentLoaded(MessageBody<Empty, Empty>),
     #[serde(rename = "get_openid")]
-    GetOpenId(MessageBody<(), openid::State>),
+    GetOpenId(MessageBody<Empty, openid::State>),
     #[serde(rename = "send_events")]
     SendEvent(MessageBody<SendEventRequest, SendEventResponse>),
     #[serde(rename = "org.matrix.msc2876.read_events")]

--- a/crates/matrix-sdk/src/widget_api/messages/mod.rs
+++ b/crates/matrix-sdk/src/widget_api/messages/mod.rs
@@ -40,6 +40,7 @@ pub struct MessageBody<Req, Resp> {
     pub header: Header,
     #[serde(rename = "data")]
     pub request: Req,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub response: Option<Response<Resp>>,
 }
 
@@ -78,6 +79,8 @@ impl<Resp> Into<Result<Resp, WidgetError>> for Response<Resp> {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+pub struct Empty{}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WidgetError {
     pub error: WidgetErrorMessage,

--- a/crates/matrix-sdk/src/widget_api/messages/to_widget.rs
+++ b/crates/matrix-sdk/src/widget_api/messages/to_widget.rs
@@ -1,18 +1,18 @@
 use serde::{Deserialize, Serialize};
 
-use super::{capabilities::Options, openid, MatrixEvent, MessageBody};
+use super::{capabilities::Options, openid, MatrixEvent, MessageBody, Empty};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "action")]
 pub enum ToWidgetMessage {
     #[serde(rename = "capabilities")]
-    SendMeCapabilities(MessageBody<(), SendMeCapabilitiesResponse>),
+    SendMeCapabilities(MessageBody<Empty, SendMeCapabilitiesResponse>),
     #[serde(rename = "notify_capabilities")]
-    CapabilitiesUpdated(MessageBody<CapabilitiesUpdatedRequest, ()>),
+    CapabilitiesUpdated(MessageBody<CapabilitiesUpdatedRequest, Empty>),
     #[serde(rename = "openid_credentials")]
-    OpenIdCredentials(MessageBody<openid::State, ()>),
+    OpenIdCredentials(MessageBody<openid::State, Empty>),
     #[serde(rename = "send_event")]
-    SendEvent(MessageBody<MatrixEvent, ()>),
+    SendEvent(MessageBody<MatrixEvent, Empty>),
 }
 
 impl ToWidgetMessage {


### PR DESCRIPTION
We need to send `response: {}` instead of `response:null` to the widget.
It is also better if we only use the response field in case it is not empty.